### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM       debian:trixie-slim
 LABEL      source_repository="https://github.com/jryberg/mosquitto-exporter"
 COPY       mosquitto-exporter /mosquitto_exporter
-RUN        apt update && \
-           apt install -y ca-certificates
+RUN        apt-get update && \
+           apt-get install -y --no-install-recommends --no-install-suggests ca-certificates && \
+           rm -rf /var/lib/apt/lists/*
 EXPOSE     9234
 ENTRYPOINT ["/mosquitto_exporter"]

--- a/Dockerfile.build-simple
+++ b/Dockerfile.build-simple
@@ -15,8 +15,9 @@ FROM debian:trixie-slim
 LABEL source_repository="https://github.com/jryberg/mosquitto-exporter"
 
 COPY --from=build /go/src/app/bin/mosquitto_exporter /mosquitto_exporter
-RUN apt update && \
-    apt install -y ca-certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --no-install-suggests ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 EXPOSE 9234
 
 ENTRYPOINT [ "/mosquitto_exporter" ]


### PR DESCRIPTION
This commit reduces Docker image size by 21 MB.

Thank you for maintaining this fork. I will appreciate if you enable the GitHub Issues so I can report future problems there.